### PR TITLE
changing language name to upper case "SAS"

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,31 +8,40 @@
         "vscode": "^1.5.0"
     },
     "bugs": {
-		"url": "https://github.com/VaccineAndDrugEvaluationCentre/vscode-sas-language/issues"
-	},
-	"homepage": "https://github.com/VaccineAndDrugEvaluationCentre/vscode-sas-language",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/VaccineAndDrugEvaluationCentre/vscode-sas-language.git"
-	},
+        "url": "https://github.com/VaccineAndDrugEvaluationCentre/vscode-sas-language/issues"
+    },
+    "homepage": "https://github.com/VaccineAndDrugEvaluationCentre/vscode-sas-language",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/VaccineAndDrugEvaluationCentre/vscode-sas-language.git"
+    },
     "categories": [
         "Languages"
     ],
     "galleryBanner": {
-		"color": "#f2a900",
-		"theme": "dark"
-	},
+        "color": "#f2a900",
+        "theme": "dark"
+    },
     "contributes": {
-        "languages": [{
-            "id": "sas",
-            "aliases": ["SAS language", "sas"],
-            "extensions": [".sas"],
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": "sas",
-            "scopeName": "source.sas",
-            "path": "./syntaxes/sas.tmLanguage"
-        }]
+        "languages": [
+            {
+                "id": "SAS",
+                "aliases": [
+                    "SAS language",
+                    "sas"
+                ],
+                "extensions": [
+                    ".sas"
+                ],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "SAS",
+                "scopeName": "source.sas",
+                "path": "./syntaxes/sas.tmLanguage"
+            }
+        ]
     }
 }


### PR DESCRIPTION
#4 

I test your changes and it did not fix the issue. 
I tried a couple combinations and determined taht **VSCODE** only use the metadata in `package.json` to identify the language name, therefore for the **Better Comments** plugin is looking for **SAS** instead of "sas".

Changing the `id` under `language` section and `language` under `grammars` did fix the issue.

Thanks for your prompt response!